### PR TITLE
Add better POI reading options

### DIFF
--- a/src/main/java/com/herronjo/chatpoi/ChatPOI.java
+++ b/src/main/java/com/herronjo/chatpoi/ChatPOI.java
@@ -1,7 +1,13 @@
 package com.herronjo.chatpoi;
 
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.TreeMap;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -9,12 +15,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.Location;
 import org.bukkit.scheduler.BukkitScheduler;
-
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Objects;
 
 public class ChatPOI extends JavaPlugin implements Listener {
     Config config = new Config();
@@ -32,7 +33,7 @@ public class ChatPOI extends JavaPlugin implements Listener {
         if (config.getDisplayFloatingText()) {
             // Summon floating text for all POIs
             PoiList poiList = new PoiList();
-            HashMap<String, POI> pois = poiList.getPOIs();
+            TreeMap<String, POI> pois = poiList.getPOIs();
             for (String poiName : pois.keySet()) {
                 POI poi = pois.get(poiName);
                 // Create invisible armor stand

--- a/src/main/java/com/herronjo/chatpoi/ChatPOI.java
+++ b/src/main/java/com/herronjo/chatpoi/ChatPOI.java
@@ -25,6 +25,7 @@ public class ChatPOI extends JavaPlugin implements Listener {
         Bukkit.getConsoleSender().sendMessage(ChatColor.GREEN + "ChatPOI has been enabled.");
         Objects.requireNonNull(getCommand("addpoi")).setExecutor(new AddPoiCommand(config, floatingTextStands));
         Objects.requireNonNull(getCommand("listpois")).setExecutor(new ListPoisCommand());
+        Objects.requireNonNull(getCommand("searchpois")).setExecutor(new SearchPoisCommand());
         Objects.requireNonNull(getCommand("removepoi")).setExecutor(new RemovePoiCommand(config, floatingTextStands));
         Objects.requireNonNull(getCommand("renamepoi")).setExecutor(new RenamePoiCommand(config, floatingTextStands));
         Objects.requireNonNull(getCommand("togglepoihud")).setExecutor(new TogglePoiHudCommand(config, floatingTextStands));

--- a/src/main/java/com/herronjo/chatpoi/ListPoisCommand.java
+++ b/src/main/java/com/herronjo/chatpoi/ListPoisCommand.java
@@ -1,7 +1,12 @@
 package com.herronjo.chatpoi;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 import java.util.TreeMap;
 
+import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -15,8 +20,50 @@ public class ListPoisCommand implements CommandExecutor {
         }
         PoiList poiList = new PoiList();
         TreeMap<String, POI> POIs = poiList.getPOIs();
+        
+        String order = "alpha";        
+        if(args.length > 0) {
+        	order = args[0];
+        }
+        
+        Collection<String> orderedNames;
+        switch(order) {
+        	case "alpha", "alphabetical", "alphanumeric":
+        		orderedNames = POIs.keySet();
+        	break;
+        	case "distance", "dist":
+        		List<String> names = new ArrayList<String>(POIs.keySet());
+        		Player player = (Player) sender;
+        		Location playerLocation = player.getLocation();
+        		String world = player.getWorld().getName();
+        		
+        		// Sort POIs in reverse order - farthest first
+        		// That way the closest POIs appear in the bottom lines of chat rather than having to scroll way up
+        		names.sort(new Comparator<String>() {
+        			@Override
+					public int compare(String a, String b) {
+        				POI poiA = POIs.get(a);
+        				POI poiB = POIs.get(b);
+        				if(a == null || b == null) throw new AssertionError("Attempted to compare non-existent POI");
+        				// Sort first by world
+        				if(poiA.world.equals(world) && !poiB.world.equals(world)) return 1;
+        				if(!poiA.world.equals(world) && poiB.world.equals(world)) return -1;
+        				if(!poiA.world.equals(world) && !poiB.world.equals(world) && !poiA.world.equals(poiB.world)) return -poiA.world.compareTo(poiB.world);
+        				// The two POIs are in the same world, sort by distance
+        				double distA = Math.pow(playerLocation.getX()-poiA.x, 2)+Math.pow(playerLocation.getY()-poiA.y, 2)+Math.pow(playerLocation.getZ()-poiA.z, 2);
+        				double distB = Math.pow(playerLocation.getX()-poiB.x, 2)+Math.pow(playerLocation.getY()-poiB.y, 2)+Math.pow(playerLocation.getZ()-poiB.z, 2);
+        				return -Double.compare(distA, distB);
+        			}
+        		});
+        		
+        		orderedNames = names;
+        		break;
+        	default:
+        		((Player) sender).sendMessage("Order must be one of alpha or distance");
+        		return false;
+        }
         ((Player) sender).sendMessage("POIs:");
-        for (String name : POIs.keySet()) {
+        for (String name : orderedNames) {
             POI poi = POIs.get(name);
             sender.sendMessage(name + ": " + poi.description + " (" + poi.world + " " + poi.x + ", " + poi.y + ", " + poi.z + ")");
         }

--- a/src/main/java/com/herronjo/chatpoi/ListPoisCommand.java
+++ b/src/main/java/com/herronjo/chatpoi/ListPoisCommand.java
@@ -1,11 +1,11 @@
 package com.herronjo.chatpoi;
 
+import java.util.TreeMap;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-
-import java.util.HashMap;
 
 public class ListPoisCommand implements CommandExecutor {
     @Override
@@ -14,7 +14,7 @@ public class ListPoisCommand implements CommandExecutor {
             return false;
         }
         PoiList poiList = new PoiList();
-        HashMap<String, POI> POIs = poiList.getPOIs();
+        TreeMap<String, POI> POIs = poiList.getPOIs();
         ((Player) sender).sendMessage("POIs:");
         for (String name : POIs.keySet()) {
             POI poi = POIs.get(name);

--- a/src/main/java/com/herronjo/chatpoi/PoiList.java
+++ b/src/main/java/com/herronjo/chatpoi/PoiList.java
@@ -1,18 +1,21 @@
 package com.herronjo.chatpoi;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.util.TreeMap;
+
 import org.bukkit.Bukkit;
 
-import java.io.*;
-import java.util.HashMap;
-
 public class PoiList {
-    private HashMap<String, POI> POIs;
+    private TreeMap<String, POI> POIs;
 
     public PoiList() {
         this.POIs = loadData("plugins/ChatPOI/pois.txt");
         if (this.POIs == null) {
             Bukkit.getConsoleSender().sendMessage("No POI data found. Creating new POI data.");
-            this.POIs = new HashMap<String, POI>();
+            this.POIs = new TreeMap<String, POI>();
             // Create ChatPOI directory if it doesn't exist
             new java.io.File("plugins/ChatPOI").mkdirs();
             saveData("plugins/ChatPOI/pois.txt");
@@ -57,7 +60,7 @@ public class PoiList {
         return POIs.get(name);
     }
 
-    public HashMap<String, POI> getPOIs() {
+    public TreeMap<String, POI> getPOIs() {
         return POIs;
     }
 
@@ -81,9 +84,9 @@ public class PoiList {
         }
     }
 
-    public static HashMap<String, POI> loadData(String filePath) {
+    public static TreeMap<String, POI> loadData(String filePath) {
         try {
-            HashMap<String, POI> poiList = new HashMap<String, POI>();
+            TreeMap<String, POI> poiList = new TreeMap<String, POI>();
             BufferedReader reader = new BufferedReader(new FileReader(filePath));
 
             String line;

--- a/src/main/java/com/herronjo/chatpoi/SearchPoisCommand.java
+++ b/src/main/java/com/herronjo/chatpoi/SearchPoisCommand.java
@@ -1,0 +1,43 @@
+package com.herronjo.chatpoi;
+
+import java.util.TreeMap;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class SearchPoisCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            return false;
+        }
+        PoiList poiList = new PoiList();
+        TreeMap<String, POI> POIs = poiList.getPOIs();
+        
+        String query = String.join(" ", args);
+        // Remove quotes if they were included to improve consistency with other ChatPOI commands
+        if(query.length() > 1 && query.charAt(0) == '"' && query.charAt(query.length()-1) == '"') {
+        	query = query.substring(1, query.length()-1);
+        }
+        boolean foundResult = false;
+        
+        for (String name : POIs.keySet()) {
+            POI poi = POIs.get(name);
+            if(name.contains(query) || poi.description.contains(query)) {
+            	if(!foundResult) {
+            		sender.sendMessage("POIs matching \""+query+"\":");
+            		foundResult = true;
+            	}
+            	sender.sendMessage(name + ": " + poi.description + " (" + poi.world + " " + poi.x + ", " + poi.y + ", " + poi.z + ")");
+            }
+        }
+        
+        if(!foundResult) {
+        	sender.sendMessage("No POIs matching \""+query+"\" found");
+        }
+        
+        return true;
+    }
+}

--- a/src/main/java/com/herronjo/chatpoi/TogglePoiHudCommand.java
+++ b/src/main/java/com/herronjo/chatpoi/TogglePoiHudCommand.java
@@ -1,5 +1,9 @@
 package com.herronjo.chatpoi;
 
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.TreeMap;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
@@ -8,9 +12,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-
-import java.util.HashMap;
-import java.util.Iterator;
 
 public class TogglePoiHudCommand implements CommandExecutor {
     Config config;
@@ -34,7 +35,7 @@ public class TogglePoiHudCommand implements CommandExecutor {
         if (config.getDisplayFloatingText()) {
             // Summon floating text for all POIs
             PoiList poiList = new PoiList();
-            HashMap<String, POI> pois = poiList.getPOIs();
+            TreeMap<String, POI> pois = poiList.getPOIs();
             for (String poiName : pois.keySet()) {
                 POI poi = pois.get(poiName);
                 // Create invisible armor stand

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,8 +10,8 @@ commands:
     permission: chatpoi.addpoi
     permission-message: You do not have permission to add a point of interest
   listpois:
-    description: Lists all points of interest on the server
-    usage: /listpois
+    description: Lists all points of interest on the server. Orderings are "alpha" and "distance", default is "alpha"
+    usage: /listpois <order>
     permission: chatpoi.listpois
     permission-message: You do not have permission to list points of interest
   removepoi:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,11 @@ commands:
     usage: /listpois <order>
     permission: chatpoi.listpois
     permission-message: You do not have permission to list points of interest
+  searchpois:
+    description: Searches all points of interest on the server for a given query.
+    usage: /searchpois <query>
+    permission: chatpoi.searchpois
+    permission-message: You do not have permission to search points of interest
   removepoi:
     description: Removes a point of interest from the server
     usage: /removepoi <name>


### PR DESCRIPTION
* Sort POIs alphabetically by default rather than by random Java hash order
  * Affects internal storage too, but this should have negligible impact unless you have millions of POIs (in which case you will have bigger issues with people DDOS'ing your server by running /listpois)
* Add option to list POIs by distance
* Add /searchpois command to search for a string in the name or description of a POI